### PR TITLE
Update branch name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ baseurl:
 permalink: "/:year/:month/:day/:title/"
 lang: fr
 repository: jamstatic/jamstatic-fr
-branch: source
+branch: master
 twitter:
   username: jamstatic_fr
 github:


### PR DESCRIPTION
The link for "Éditez le contenu" in posts footer currently points to the non existing "source" branch.